### PR TITLE
feat: redesign Settings panel for App Store readiness

### DIFF
--- a/ComTab/ComTabApp.swift
+++ b/ComTab/ComTabApp.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import AppKit
+import StoreKit
 
 @main
 struct ComTabApp: App {
@@ -14,7 +15,6 @@ struct ComTabApp: App {
     @StateObject private var activationMonitor = ActivationMonitor()
 
     var body: some Scene {
-        // 无主窗口，仅提供设置面板以供需要时调整开关
         Settings {
             SettingsView()
                 .environmentObject(activationMonitor)
@@ -24,12 +24,86 @@ struct ComTabApp: App {
 
 private struct SettingsView: View {
     @EnvironmentObject private var activationMonitor: ActivationMonitor
+    @StateObject private var launchManager = LaunchAtLoginManager()
+
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+    }
+
+    private var buildNumber: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+    }
 
     var body: some View {
         Form {
-            Toggle("自动重新打开前台应用", isOn: activationMonitor.featureToggleBinding)
+            Section {
+                Toggle("Auto-reopen windows", isOn: activationMonitor.featureToggleBinding)
+                if #available(macOS 13.0, *) {
+                    Toggle("Launch at Login", isOn: launchManager.binding)
+                }
+            } header: {
+                Text("General")
+            }
+
+            Section {
+                Button {
+                    requestReview()
+                } label: {
+                    Label("Rate on App Store", systemImage: "star.fill")
+                }
+                .buttonStyle(.link)
+
+                Button {
+                    if let url = URL(string: "mailto:fchen6611@gmail.com") {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    Label("Contact Developer", systemImage: "envelope")
+                }
+                .buttonStyle(.link)
+
+                Button {
+                    if let url = URL(string: "https://github.com/Feng6611/mac-command-reopen") {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    Label("GitHub", systemImage: "chevron.left.forwardslash.chevron.right")
+                }
+                .buttonStyle(.link)
+            } header: {
+                Text("Feedback & Support")
+            }
+
+            Section {
+                HStack {
+                    Spacer()
+                    Text("Command Reopen v\(appVersion) (\(buildNumber))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                }
+            }
         }
+        .formStyle(.grouped)
         .padding(20)
-        .frame(width: 320)
+        .frame(width: 380, height: 320)
+    }
+
+    private func requestReview() {
+        if #available(macOS 14.0, *) {
+            // Use the environment-based review request on macOS 14+
+            // For simplicity, fall back to opening App Store URL
+            openAppStoreReview()
+        } else {
+            openAppStoreReview()
+        }
+    }
+
+    private func openAppStoreReview() {
+        // Replace APP_ID with actual App Store ID after publishing
+        let appStoreURL = "macappstore://apps.apple.com/app/idAPP_ID?action=write-review"
+        if let url = URL(string: appStoreURL) {
+            NSWorkspace.shared.open(url)
+        }
     }
 }


### PR DESCRIPTION
## Summary

Redesign the minimal Settings panel into a complete preferences window, preparing for Mac App Store submission.

## Changes

### General Section
- **Auto-reopen windows** toggle (existing, preserved)
- **Launch at Login** toggle via `SMAppService` (macOS 13+, gracefully hidden on 12)

### Feedback & Support Section
- **Rate on App Store** — opens App Store review page (placeholder ID, replace after publishing)
- **Contact Developer** — opens `mailto:fchen6611@gmail.com`
- **GitHub** — links to this repository

### Footer
- Displays app version and build number from Bundle

## Design Decisions
- UI text in English (global audience)
- SwiftUI `Form` + `Section` with `.grouped` style for native macOS feel
- Width increased from 320 → 380 for better layout
- No new permissions required
- Minimum deployment: macOS 12.0

## TODO after merge
- Replace `APP_ID` placeholder in `openAppStoreReview()` with actual App Store ID
- Consider adding localization (Chinese) for Settings labels